### PR TITLE
Fix link to esbuild section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Mapkick uses [Mapbox GL JS v1](https://github.com/mapbox/mapbox-gl-js/tree/v1.13
 Then follow the instructions for your JavaScript setup:
 
 - [Importmap](#importmap) (Rails 7 default)
-- [esbuild, rollup.js, or Webpack](#esbuild-rollupjs-or-webpack)
+- [esbuild, rollup.js, or Webpack](#esbuild-rollup-js-or-webpack)
 - [Webpacker](#webpacker) (Rails 6 default)
 - [Sprockets](#sprockets)
 


### PR DESCRIPTION
The link to the `#esbuild-rollup-js-or-webpack` section is broken because it is missing a `-` between `rollup` and `js`. This change fixes that link.

### Old code
`[esbuild, rollup.js, or Webpack](#esbuild-rollupjs-or-webpack)`

### New code
`[esbuild, rollup.js, or Webpack](#esbuild-rollup-js-or-webpack)`